### PR TITLE
Added support for UTF8 encoding 

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -7,10 +7,60 @@ function string_to_bytes ( str ) {
         arr = new Uint8Array( len );
     for ( var i = 0; i < len; i++ ) {
         var c = str.charCodeAt(i);
-        if ( c >>> 8 ) throw new Error("Wide characters are not allowed");
+        if ( c >>> 8 ) throw new Error("Wide characters are not allowed. Use string_to_utf8bytes.");
         arr[i] = c;
     }
     return arr;
+}
+
+function string_to_utf8bytes ( str ) {
+
+	function fixedCharCodeAt(str, idx) {
+	  idx = idx || 0;
+	  var code = str.charCodeAt(idx);
+	  var hi, low;
+	  
+	  // High surrogate (could change last hex to 0xDB7F to treat high
+	  // private surrogates as single characters)
+	  if (0xd800 <= code && code <= 0xdbff) {
+		hi = code;
+		low = str.charCodeAt(idx + 1);
+		if (isNaN(low)) {
+		  throw 'High surrogate not followed by low surrogate in fixedCharCodeAt()';
+		}
+		return ((hi - 0xd800) * 0x400) + (low - 0xdc00) + 0x10000;
+	  }
+	  if (0xdc00 <= code && code <= 0xdfff) { // Low surrogate
+		// We return false to allow loops to skip this iteration since should have
+		// already handled high surrogate above in the previous iteration
+		return false;
+	  }
+	  return code;
+	}
+
+	var len = str.length,
+        bytes = [];
+    for ( var i = 0; i < len; i++ ) {
+        var c = fixedCharCodeAt(str, i);
+		if (c === false) continue;
+		
+        if (c <= 0x7f) {
+            bytes.push(c);
+        } else if (c <= 0x7ff) {
+            bytes.push((c >> 6) | 0xc0);
+            bytes.push((c & 0x3F) | 0x80);
+        } else if (c <= 0xffff) {
+            bytes.push((c >> 12) | 0xe0);
+            bytes.push(((c >> 6) & 0x3f) | 0x80);
+            bytes.push((c & 0x3f) | 0x80);
+        } else {
+            bytes.push((c >> 18) | 0xf0);
+            bytes.push(((c >> 12) & 0x3f) | 0x80);
+            bytes.push(((c >> 6) & 0x3f) | 0x80);
+            bytes.push((c & 0x3f) | 0x80);
+        }
+    }
+    return new Uint8Array(bytes);
 }
 
 function hex_to_bytes ( str ) {
@@ -34,6 +84,35 @@ function base64_to_bytes ( str ) {
 function bytes_to_string ( arr ) {
     var str = '';
     for ( var i = 0; i < arr.length; i++ ) str += String.fromCharCode( arr[i] );
+    return str;
+}
+
+function utf8bytes_to_string ( arr ) {
+	var len = arr.length,
+        str = '';
+    for ( var i = 0; i < len; i++ ) {
+        if (arr[i] < 128) {
+            str += String.fromCharCode( arr[i] );
+        } else if (arr[i] >= 192 && arr[i] < 224 && (i + 1 < len)) {
+			str += String.fromCharCode(((arr[i] & 0x1f) << 6) | (arr[++i] & 0x3f));
+		} else if (arr[i] >= 224 && arr[i] < 240 && (i + 2 < len)) {
+            str += String.fromCharCode(((arr[i] & 0xf) << 12) | ((arr[++i] & 0x3f) << 6) | (arr[++i] & 0x3f));
+		} else if (arr[i] >= 240 && arr[i] < 248 && (i + 3 < len)) {
+			var unicodePoint = ((arr[i] & 7) << 18) | ((arr[++i] & 0x3f) << 12) | ((arr[++i] & 0x3f) << 6) | (arr[++i] & 0x3f);
+			if (unicodePoint <= 0xffff) {
+				str += String.fromCharCode(unicodePoint);
+			}
+			else {
+				unicodePoint -= 0x10000;
+				highSurrogate = (unicodePoint >> 10) + 0xd800;
+				lowSurrogate = (unicodePoint % 0x400) + 0xdc00;
+				str += String.fromCharCode(highSurrogate, lowSurrogate);
+			}
+        } else {
+			console.log(arr[i]);
+			throw new Error("Not a UTF8 encoded byte array.");
+		}
+    }
     return str;
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -101,8 +101,19 @@ function utf8bytes_to_string ( arr ) {
 			throw new Error("Not a UTF8 encoded byte array.");
 		}
     }
-		
-    return String.fromCharCode.apply(null, strBuffer.subarray(0, j));
+	
+	var batchSize = 16384;
+	if (j < batchSize) {
+		return String.fromCharCode.apply(null, strBuffer.subarray(0, j));
+	}
+
+	var str = '';
+	for (var i = 0; i < j; i += batchSize) {
+		var batch = strBuffer.subarray(i, i + batchSize > j ? j : i + batchSize);
+		str += String.fromCharCode.apply(null, batch);
+	}
+	
+	return str;
 }
 
 function bytes_to_hex ( arr ) {


### PR DESCRIPTION
Hi Artem, I've created a pull request to add UTF8 support as the most widespread encoding nowadays. Not sure how to add proper tests to the solution, but tested locally.
Used "🚀" rocket as an example of 4-byte UTF8 char.
Used code samples:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint
http://stackoverflow.com/questions/15181809/javascript-charcodeat0-stuck-at-55357
https://gist.github.com/volodymyr-mykhailyk/2923227

Additional info: https://en.wikipedia.org/wiki/UTF-8