### PR TITLE
Replaced forced global variable with UMD

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -380,7 +380,6 @@ module.exports = function ( grunt ) {
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-saucelabs');
     grunt.loadNpmTasks('grunt-jsdoc');
-    grunt.loadNpmTasks('grunt-umd');
 
     function sources () {
         // Get the list of modules split by commas
@@ -461,8 +460,10 @@ module.exports = function ( grunt ) {
         concat: {
             options: {
                 banner: "/*! asmCrypto<%= pkg.version && ' v'+pkg.version %>, (c) 2013 <%= pkg.author.name %>, opensource.org/licenses/<%= pkg.license %> */\n"
-                      + "var exports = (function ( exports, global ) {\n\n",
-                footer: "\n\nreturn exports;\n})( {}, function(){return this}() );",
+                      + "(function ( exports, global ) {\n\n",
+                footer: "\n\n'function'==typeof define&&define.amd?define([],function(){return exports}):"
+                      + "'object'==typeof module&&module.exports?module.exports=exports:global.asmCrypto=exports;"
+                      + "\n\nreturn exports;\n})( {}, function(){return this}() );",
                 sourceMap: true,
                 sourceMapStyle: 'link'
             },
@@ -470,16 +471,6 @@ module.exports = function ( grunt ) {
                 files: {
                     'asmcrypto.js': '<%= sources.files %>'
                 }
-            }
-        },
-
-        umd: {
-            all: {
-                src: 'asmcrypto.js',
-                dest: 'asmcrypto.js',
-                template: 'umd',
-                objectToExport: 'exports',
-                globalAlias: 'asmCrypto'
             }
         },
 
@@ -543,7 +534,7 @@ module.exports = function ( grunt ) {
         watch: {
             all: {
                 files: '<%= sources.files %>',
-                tasks: ['sources','concat','umd']
+                tasks: ['sources','concat']
             }
         },
 
@@ -555,8 +546,8 @@ module.exports = function ( grunt ) {
     });
 
     grunt.registerTask('sources', sources);
-    grunt.registerTask('default', ['sources','concat','umd','uglify']);
-    grunt.registerTask('devel', ['sources','concat','umd','connect','watch']);
+    grunt.registerTask('default', ['sources','concat','uglify']);
+    grunt.registerTask('devel', ['sources','concat','connect','watch']);
     grunt.registerTask('test', ['connect','qunit']);
     grunt.registerTask('sauce', ['connect','saucelabs-qunit']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -474,7 +474,7 @@ module.exports = function ( grunt ) {
         },
 
         umd: {
-            release: {
+            all: {
                 src: 'asmcrypto.js',
                 dest: 'asmcrypto.js',
                 template: 'umd',
@@ -543,7 +543,7 @@ module.exports = function ( grunt ) {
         watch: {
             all: {
                 files: '<%= sources.files %>',
-                tasks: ['sources','concat']
+                tasks: ['sources','concat','umd']
             }
         },
 
@@ -556,7 +556,7 @@ module.exports = function ( grunt ) {
 
     grunt.registerTask('sources', sources);
     grunt.registerTask('default', ['sources','concat','umd','uglify']);
-    grunt.registerTask('devel', ['sources','concat','connect','watch']);
+    grunt.registerTask('devel', ['sources','concat','umd','connect','watch']);
     grunt.registerTask('test', ['connect','qunit']);
     grunt.registerTask('sauce', ['connect','saucelabs-qunit']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -380,6 +380,7 @@ module.exports = function ( grunt ) {
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-saucelabs');
     grunt.loadNpmTasks('grunt-jsdoc');
+    grunt.loadNpmTasks('grunt-umd');
 
     function sources () {
         // Get the list of modules split by commas
@@ -460,8 +461,8 @@ module.exports = function ( grunt ) {
         concat: {
             options: {
                 banner: "/*! asmCrypto<%= pkg.version && ' v'+pkg.version %>, (c) 2013 <%= pkg.author.name %>, opensource.org/licenses/<%= pkg.license %> */\n"
-                      + "!function ( exports, global ) {\n\n",
-                footer: "\nglobal.asmCrypto=exports;\n}( {}, function(){return this}() );",
+                      + "var exports = (function ( exports, global ) {\n\n",
+                footer: "\n\nreturn exports;\n})( {}, function(){return this}() );",
                 sourceMap: true,
                 sourceMapStyle: 'link'
             },
@@ -472,11 +473,20 @@ module.exports = function ( grunt ) {
             }
         },
 
+        umd: {
+            release: {
+                src: 'asmcrypto.js',
+                dest: 'asmcrypto.js',
+                template: 'umd',
+                objectToExport: 'exports',
+                globalAlias: 'asmCrypto'
+            }
+        },
+
         uglify: {
             options: {
                 mangle: {},
                 compress: {},
-                wrap: 'asmCrypto',
                 sourceMap: true,
                 sourceMapIncludeSources: true,
                 screwIE8: true,
@@ -484,7 +494,7 @@ module.exports = function ( grunt ) {
             },
             release: {
                 files: {
-                    'asmcrypto.js': '<%= sources.files %>'
+                    'asmcrypto.js': 'asmcrypto.js'
                 }
             }
         },
@@ -545,7 +555,7 @@ module.exports = function ( grunt ) {
     });
 
     grunt.registerTask('sources', sources);
-    grunt.registerTask('default', ['sources','uglify']);
+    grunt.registerTask('default', ['sources','concat','umd','uglify']);
     grunt.registerTask('devel', ['sources','concat','connect','watch']);
     grunt.registerTask('test', ['connect','qunit']);
     grunt.registerTask('sauce', ['connect','saucelabs-qunit']);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
         "grunt-contrib-watch": "~0.2",
         "grunt-contrib-clean": "~0.4",
         "grunt-saucelabs": "~8.0",
-        "grunt-jsdoc": "~0.6"
+        "grunt-jsdoc": "~0.6",
+        "grunt-umd": "^2.3.3"
     },
     "engines": {
         "node": "~0.10"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
         "grunt-contrib-watch": "~0.2",
         "grunt-contrib-clean": "~0.4",
         "grunt-saucelabs": "~8.0",
-        "grunt-jsdoc": "~0.6",
-        "grunt-umd": "^2.3.3"
+        "grunt-jsdoc": "~0.6"
     },
     "engines": {
         "node": "~0.10"


### PR DESCRIPTION
Thanks for such great project!
I have replaced global `asmCrypto` variable with <a href="https://github.com/umdjs/umd">UMD (Universal Module Definition)</a> pattern, so the library could be accessible in node.js with:
```javascript
var asmCrypto = require('asmcrypto');
```
Now require returns nothing and requiring this file results with adding `asmCrypto` variable to global space. This is very unusual behavior for node.js modules.
Also this patch fixes behavior for AMD module systems (like require.js).