### PR TITLE
Do not crash when running in node.js

### DIFF
--- a/src/origin.js
+++ b/src/origin.js
@@ -1,6 +1,6 @@
 var _global_console = global.console;
 
-var _secure_origin = !global.location.protocol.search( /https:|file:|chrome:|chrome-extension:/ );
+var _secure_origin = (global.location === undefined) || !global.location.protocol.search( /https:|file:|chrome:|chrome-extension:/ );
 
 if ( !_secure_origin && _global_console !== undefined ) {
     _global_console.warn("asmCrypto seems to be load from an insecure origin; this may cause to MitM-attack vulnerability. Consider using secure transport protocol.");


### PR DESCRIPTION
The node.js environment has no concept of a document origin.
Therefore, the secure-origin test crashes on an undefined variable.
If we see this case, we can assume the origin is secure.

This is maybe a better way to solve vibornoff/asmcrypto.js#100
