### PR TITLE
create new object for asm.js stdlib

### DIFF
--- a/src/aes/aes.asm.js
+++ b/src/aes/aes.asm.js
@@ -136,11 +136,11 @@ var AES_asm = function () {
      *
      * @alias AES_asm
      * @class
-     * @param {GlobalScope} stdlib - global scope object (e.g. <code>window</code>)
+     * @param {GlobalScope} global - global scope object (e.g. <code>window</code>)
      * @param {Object} foreign - <i>ignored</i>
      * @param {ArrayBuffer} buffer - heap buffer to link with
      */
-    var wrapper = function ( stdlib, foreign, buffer ) {
+    var wrapper = function ( global, foreign, buffer ) {
         // Init AES stuff for the first time
         if ( !aes_init_done ) aes_init();
 
@@ -196,6 +196,9 @@ var AES_asm = function () {
             // Set rounds number
             asm.set_rounds( ks + 5 );
         }
+
+        // create library object with necessary properties
+        var stdlib = { Uint8Array: Uint8Array, Uint32Array: Uint32Array };
 
         var asm = function ( stdlib, foreign, buffer ) {
             "use asm";

--- a/src/bignum/bigint.asm.js
+++ b/src/bignum/bigint.asm.js
@@ -1,26 +1,9 @@
-var bigint_asm;
-
-if ( global.Math.imul === undefined ) {
-    function _half_imul ( a, b ) {
-        return a * b | 0;
-    }
-    bigint_asm = function ( stdlib, foreign, buffer ) {
-        global.Math.imul = _half_imul;
-        var m = _bigint_asm( stdlib, foreign, buffer );
-        delete global.Math.imul;
-        return m;
-    };
-}
-else {
-    bigint_asm = _bigint_asm;
-}
-
 /**
  * Integers are represented as little endian array of 32-bit limbs.
  * Limbs number is a power of 2 and a multiple of 8 (256 bits).
  * Negative values use two's complement representation.
  */
-function _bigint_asm ( stdlib, foreign, buffer ) {
+function bigint_asm ( stdlib, foreign, buffer ) {
     "use asm";
 
     var SP = 0;

--- a/src/bignum/bignum.js
+++ b/src/bignum/bignum.js
@@ -4,8 +4,16 @@ function is_big_number ( a ) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+var _bigint_stdlib = { Uint32Array: Uint32Array, Math: global.Math };
+
+if ( _bigint_stdlib .Math.imul === undefined ) {
+    _bigint_stdlib .Math.imul = function _half_imul ( a, b ) {
+        return a * b | 0;
+    }
+}
+
 var _bigint_heap = new Uint32Array(0x100000),
-    _bigint_asm = bigint_asm( global, null, _bigint_heap.buffer );
+    _bigint_asm = bigint_asm( _bigint_stdlib, null, _bigint_heap.buffer );
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/src/hash/sha1/sha1.js
+++ b/src/hash/sha1/sha1.js
@@ -5,7 +5,7 @@ function sha1_constructor ( options ) {
     options = options || {};
 
     this.heap = _heap_init( Uint8Array, options );
-    this.asm = options.asm || sha1_asm( global, null, this.heap.buffer );
+    this.asm = options.asm || sha1_asm( { Uint8Array: Uint8Array }, null, this.heap.buffer );
 
     this.BLOCK_SIZE = _sha1_block_size;
     this.HASH_SIZE = _sha1_hash_size;

--- a/src/hash/sha256/sha256.js
+++ b/src/hash/sha256/sha256.js
@@ -5,7 +5,7 @@ function sha256_constructor ( options ) {
     options = options || {};
 
     this.heap = _heap_init( Uint8Array, options );
-    this.asm = options.asm || sha256_asm( global, null, this.heap.buffer );
+    this.asm = options.asm || sha256_asm( { Uint8Array: Uint8Array }, null, this.heap.buffer );
 
     this.BLOCK_SIZE = _sha256_block_size;
     this.HASH_SIZE = _sha256_hash_size;

--- a/src/hash/sha512/sha512.js
+++ b/src/hash/sha512/sha512.js
@@ -5,7 +5,7 @@ function sha512_constructor ( options ) {
     options = options || {};
 
     this.heap = _heap_init( Uint8Array, options );
-    this.asm = options.asm || sha512_asm( global, null, this.heap.buffer );
+    this.asm = options.asm || sha512_asm( { Uint8Array: Uint8Array }, null, this.heap.buffer );
 
     this.BLOCK_SIZE = _sha512_block_size;
     this.HASH_SIZE = _sha512_hash_size;


### PR DESCRIPTION
Rather than directly passing the global object, this change refactors to only pass the necessary properties to the asm.js modules.

This works around a bug in Edge which causes a large slowdown on asm.js applications when using the global object for the stdlib, unless you are running with experimental JS features enabled.

I have a PR to fix the bug in Chakra as well (https://github.com/Microsoft/ChakraCore/pull/1555), but it will take some time before that makes its way back into Edge.
