### PR TITLE
include pbkdf2-hmac-sha512 module in gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,7 @@ var defaults = [
     'hmac-sha256',
     'pbkdf2-hmac-sha1',
     'pbkdf2-hmac-sha256',
+    'pbkdf2-hmac-sha512',
     'rng',
     'bn',
     'rsa-pkcs1',


### PR DESCRIPTION
hey there! i needed to use sha512 of pbkdf2, and it wasn't in the gruntfile despite being in /src/, so here it is 😄 