### PR TITLE
Suppress "insecure origin" warning if script is loaded from a Firefox WebExtension

### DIFF
--- a/src/origin.js
+++ b/src/origin.js
@@ -1,6 +1,6 @@
 var _global_console = global.console;
 
-var _secure_origin = (global.location === undefined) || !global.location.protocol.search( /https:|file:|chrome:|chrome-extension:/ );
+var _secure_origin = (global.location === undefined) || !global.location.protocol.search( /https:|file:|chrome:|chrome-extension:|moz-extension:/ );
 
 if ( !_secure_origin && _global_console !== undefined ) {
     _global_console.warn("asmCrypto seems to be load from an insecure origin; this may cause to MitM-attack vulnerability. Consider using secure transport protocol.");


### PR DESCRIPTION
In the same vein as "chrome-extension:", the "moz-extension:" protocol is used by Mozilla Firefox to access files within locally installed browser extensions. As such it is not susceptible to MitM attacks.

Point of note: there seems to be a W3C proposal being worked on that will unify the browser protocol for files in local extensions as "browserext:". However, since that is not in use anywhere yet and the proposal is not official at this point, I am not including it in this pull request.

Proposal link: https://browserext.github.io/browserext/